### PR TITLE
fix: make navigation work in storyblok

### DIFF
--- a/app/lib/storyblok.server.ts
+++ b/app/lib/storyblok.server.ts
@@ -64,7 +64,10 @@ export async function getVacancyBySlug(
 export async function getAllVacancies(
   preview = false,
 ): Promise<StoryData<VacancyStoryContent>[] | undefined> {
-  const params = { ...getDefaultParams({ preview }), starts_with: 'careers/' }
+  const params = {
+    ...getDefaultParams({ preview }),
+    starts_with: 'careers/',
+  }
 
   try {
     return getStoryblokApi().getAll(`cdn/stories`, params)

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -139,11 +139,11 @@ export async function loader({ request }: DataFunctionArgs) {
 
 export function App() {
   const data = useTypedLoaderData<typeof loader>()
-  const story = useStoryblokState(data.initialStory, {}, data.preview)
+  // const story = useStoryblokState(data.initialStory, {}, data.preview)
   const location = useLocation()
 
-  const [navigation] = story.content.navigation
-  const [footer] = story.content.footer
+  const [navigation] = data.initialStory?.content.navigation ?? []
+  const [footer] = data.initialStory?.content.footer ?? []
 
   React.useEffect(() => {
     if (data.ENV.GOOGLE_ANALYTICS?.length) {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -10,19 +10,13 @@ import {
   Links,
   LiveReload,
   Meta,
-  Outlet,
   Scripts,
   ScrollRestoration,
   useCatch,
   useLocation,
 } from '@remix-run/react'
 
-import {
-  storyblokInit,
-  apiPlugin,
-  useStoryblokState,
-  StoryblokComponent,
-} from '@storyblok/react'
+import { storyblokInit, apiPlugin, StoryblokComponent } from '@storyblok/react'
 
 import { typedjson, useTypedLoaderData } from 'remix-typedjson'
 
@@ -58,17 +52,6 @@ storyblokInit({
     },
   },
 })
-
-export const meta: MetaFunction = ({ data }) => {
-  const requestInfo = data?.requestInfo
-
-  return {
-    charset: 'utf-8',
-    title: 'Salt',
-    viewport: 'width=device-width,initial-scale=1,viewport-fit=cover',
-    canonical: removeTrailingSlash(`${requestInfo.origin}${requestInfo.path}`),
-  }
-}
 
 export const links: LinksFunction = () => {
   return [
@@ -116,14 +99,14 @@ export type LoaderData = SerializeFrom<typeof loader>
 
 export async function loader({ request }: DataFunctionArgs) {
   const preview = isPreview(request)
-  const [initialStory, labels, vacancies] = await Promise.all([
+  const [layoutStory, labels, vacancies] = await Promise.all([
     getLayout(),
     getDataSource('labels'),
     getAllVacancies(preview),
   ])
 
   const data = {
-    initialStory,
+    layoutStory,
     preview,
     labels,
     vacancies,
@@ -137,13 +120,20 @@ export async function loader({ request }: DataFunctionArgs) {
   return typedjson(data)
 }
 
+export const meta: MetaFunction = ({ data }) => {
+  const requestInfo = data?.requestInfo
+
+  return {
+    charset: 'utf-8',
+    title: 'Salt',
+    viewport: 'width=device-width,initial-scale=1,viewport-fit=cover',
+    canonical: removeTrailingSlash(`${requestInfo.origin}${requestInfo.path}`),
+  }
+}
+
 export function App() {
   const data = useTypedLoaderData<typeof loader>()
-  // const story = useStoryblokState(data.initialStory, {}, data.preview)
   const location = useLocation()
-
-  const [navigation] = data.initialStory?.content.navigation ?? []
-  const [footer] = data.initialStory?.content.footer ?? []
 
   React.useEffect(() => {
     if (data.ENV.GOOGLE_ANALYTICS?.length) {
@@ -188,9 +178,7 @@ export function App() {
         )}
       </head>
       <body>
-        <StoryblokComponent blok={navigation} key={navigation._uid} />
-        <Outlet />
-        <StoryblokComponent blok={footer} key={footer._uid} />
+        <StoryblokComponent blok={data.layoutStory?.content} />
         <ScrollRestoration />
         <Scripts />
         <script

--- a/app/routes/$slug.tsx
+++ b/app/routes/$slug.tsx
@@ -28,11 +28,14 @@ export const handle: Handle = {
 }
 
 export async function loader({ params, request }: DataFunctionArgs) {
-  if (pathedRoutes[new URL(request.url).pathname]) {
+  const preview = isPreview(request)
+  const { pathname } = new URL(request.url)
+
+  // Block the layout path when not in preview mode
+  if (pathedRoutes[pathname] || (!preview && pathname === '/layout')) {
     throw new Response('Use other route', { status: 404 })
   }
 
-  const preview = isPreview(request)
   const initialStory = await getStoryBySlug(params.slug ?? 'home', preview)
 
   if (!initialStory) {

--- a/app/storyblok/index.ts
+++ b/app/storyblok/index.ts
@@ -14,21 +14,30 @@ import { SbLocationSection } from './sections/location-section'
 import { SbPeopleSection } from './sections/people-section'
 import { SbTextSection } from './sections/text-section'
 import { SbVacancy } from './vacancy'
+import { SbLayout } from '~/storyblok/layout'
 
 // Would prefer to put this in types/storyblok.d.ts but that breaks the build for some reason 🤷
 export enum BlokTypes {
+  // Content types
   Page = 'page',
+  Vacancy = 'vacancy',
+
+  // Global components
+  Layout = 'layout',
   Navigation = 'navigation',
   Footer = 'footer',
-  Hero = 'hero',
+
+  // Nested Components
   Button = 'button',
   Link = 'link',
-  Vacancy = 'vacancy',
+
+  // Components
+  Hero = 'hero',
+  Quote = 'quote',
   Clients = 'clients',
   Calculator = 'calculator',
-  TextSection = 'textSection',
   BlockWithSections = 'blockWithSections',
-  Quote = 'quote',
+  TextSection = 'textSection',
   PeopleSection = 'peopleSection',
   CareersSection = 'careersSection',
   HeaderSection = 'headerSection',
@@ -39,6 +48,7 @@ export enum BlokTypes {
 export const components = {
   [BlokTypes.Page]: SbPage,
   [BlokTypes.Vacancy]: SbVacancy,
+  [BlokTypes.Layout]: SbLayout,
   [BlokTypes.Navigation]: SbNavigation,
   [BlokTypes.Footer]: SbFooter,
   [BlokTypes.Hero]: SbHeroSection,

--- a/app/storyblok/layout.tsx
+++ b/app/storyblok/layout.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react'
+
+import { Outlet } from '@remix-run/react'
+
+import { StoryblokComponent } from '@storyblok/react'
+
+import type { LayoutBlok } from '~/types'
+import { StoryBlokWrapper } from '~/utils/storyblok'
+
+export function SbLayout({ blok }: { blok: LayoutBlok }) {
+  return (
+    <StoryBlokWrapper blok={blok}>
+      <StoryblokComponent blok={blok.navigation[0]} />
+      <Outlet />
+      <StoryblokComponent blok={blok.footer[0]} />
+    </StoryBlokWrapper>
+  )
+}

--- a/types/storyblok.d.ts
+++ b/types/storyblok.d.ts
@@ -18,6 +18,11 @@ export type LayoutStoryContent = {
   footer: FooterBlok[]
 }
 
+export type LayoutBlok = SbBlokData & {
+  navigation: NavigationBlok[]
+  footer: FooterBlok[]
+}
+
 export type NavigationBlok = SbBlokData & {
   component: BlokTypes.Navigation
   menu: LinkBlok[]


### PR DESCRIPTION
Properly implement storyblok layout component that will render navigation and footer. 
Remove usage of `useStoryblokState` from root so it's only rendered once on every page.